### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,7 +8,7 @@
 # Enumerators
 
 # Classes
-ExponentMap
+ExponentMap						KEYWORD1
 
 
 ########################################
@@ -18,8 +18,8 @@ ExponentMap
 # Global functions
 EM_DEBUG						KEYWORD2
 EM_DEBUGLN						KEYWORD2
-EM_PRINT                        KEYWORD2
-EM_PRINTLN                      KEYWORD2
+EM_PRINT						KEYWORD2
+EM_PRINTLN						KEYWORD2
 
 # class ExponentMap
 stepToValue						KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords