### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,7 +8,7 @@
 # Enumerators
 
 # Classes
-ExponentMap						KEYWORD1
+ExponentMap	KEYWORD1
 
 
 ########################################
@@ -16,19 +16,19 @@ ExponentMap						KEYWORD1
 ########################################
 
 # Global functions
-EM_DEBUG						KEYWORD2
-EM_DEBUGLN						KEYWORD2
-EM_PRINT						KEYWORD2
-EM_PRINTLN						KEYWORD2
+EM_DEBUG	KEYWORD2
+EM_DEBUGLN	KEYWORD2
+EM_PRINT	KEYWORD2
+EM_PRINTLN	KEYWORD2
 
 # class ExponentMap
-stepToValue						KEYWORD2
-valueToSteps					KEYWORD2
-stepsCount						KEYWORD2
-stepsRepeat						KEYWORD2
-printTable						KEYWORD2
-printCode						KEYWORD2
-calculateMap					KEYWORD2
+stepToValue	KEYWORD2
+valueToSteps	KEYWORD2
+stepsCount	KEYWORD2
+stepsRepeat	KEYWORD2
+printTable	KEYWORD2
+printCode	KEYWORD2
+calculateMap	KEYWORD2
 
 
 ########################################
@@ -36,6 +36,6 @@ calculateMap					KEYWORD2
 ########################################
 
 # Global constants
-optimalExponentDivider			LITERAL1
+optimalExponentDivider	LITERAL1
 
-EXPONENTMAP_DEBUG				LITERAL1
+EXPONENTMAP_DEBUG	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords